### PR TITLE
Feat/24/mypage scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-intersection-observer": "^10.0.3",
         "shadcn": "^4.2.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
@@ -75,7 +76,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -600,7 +600,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1766,7 +1765,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3696,7 +3694,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.2.tgz",
       "integrity": "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.96.2"
       },
@@ -3838,7 +3835,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3849,7 +3845,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3860,7 +3855,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3922,7 +3916,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -4461,7 +4454,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4909,7 +4901,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5638,8 +5629,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5920,7 +5910,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6106,7 +6095,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6396,7 +6384,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7091,7 +7078,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9493,7 +9479,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9503,12 +9488,26 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-10.0.3.tgz",
+      "integrity": "sha512-luICLMbs0zxTO/70Zy7K5jOXkABPEVSAF8T3FdZUlctsrIaPLmx8TZe2SSA+CY2HGWfz2INyNTnp82pxNNsShA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -10649,7 +10648,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10898,7 +10896,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11487,7 +11484,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-intersection-observer": "^10.0.3",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/src/app/(webview)/mypage/likes/page.tsx
+++ b/src/app/(webview)/mypage/likes/page.tsx
@@ -2,6 +2,7 @@
 
 import MyNestList from "@/components/webview/mypage/MyNestList";
 import MypageHeader from '@/components/webview/mypage/MyPageHeader';
+import Spinner from "@/components/webview/Spinner";
 
 import { useState } from "react";
 import { fetchLikesNests } from "@/lib/apiMypage";
@@ -13,7 +14,6 @@ export default function Page() {
     if (typeof window === "undefined") return "";
     try {
       const token = window.AndroidBridge.getAccessToken();
-      console.log(token, "좋아요 둥지");
       return token ?? "";
     } catch {
       return "";
@@ -41,7 +41,11 @@ export default function Page() {
   const allNests = nestsData?.pages.flatMap((page) => page.data.content) || [];
 
   if (!accessToken || isLikesLoading) {
-    return <div className="flex justify-center items-center h-screen">로딩 중...</div>;
+    return (
+          <div className="flex justify-center items-center h-screen bg-white">
+            <Spinner size="lg" />
+          </div>
+      );
   }
 
   return (

--- a/src/app/(webview)/mypage/likes/page.tsx
+++ b/src/app/(webview)/mypage/likes/page.tsx
@@ -5,7 +5,7 @@ import MypageHeader from '@/components/webview/mypage/MyPageHeader';
 
 import { useState } from "react";
 import { fetchLikesNests } from "@/lib/apiMypage";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 export default function Page() {
   //브릿지로 accesstoken 수신
@@ -20,21 +20,34 @@ export default function Page() {
     }
   });
 
-  //좋아요 누른 둥지 정보
-  const { data: nestsData, isLoading: isNestLoading} = useQuery({
-    queryKey: ['userNests', accessToken],
-    queryFn: () => fetchLikesNests(accessToken),
+  // 좋아요 누른 둥지 정보
+  const { 
+    data: nestsData, 
+    isLoading: isLikesLoading,
+    fetchNextPage,      // 다음 페이지를 불러오는 함수
+    hasNextPage,        // 다음 페이지가 있는지 여부 (last 기반)
+    isFetchingNextPage  // 추가 페이지를 로딩 중인지 여부
+  } = useInfiniteQuery({
+    queryKey: ['likedNests', accessToken],
+    queryFn: ({ pageParam = 0 }) => fetchLikesNests(accessToken, pageParam), 
     enabled: !!accessToken,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.data.last) return undefined;
+      return lastPage.data.number + 1;
+    },
   });
 
-  if (!accessToken || isNestLoading) {
+  const allNests = nestsData?.pages.flatMap((page) => page.data.content) || [];
+
+  if (!accessToken || isLikesLoading) {
     return <div className="flex justify-center items-center h-screen">로딩 중...</div>;
   }
 
   return (
     <div>
       <MypageHeader title='좋아요 둥지'/>
-      <MyNestList nestsData={nestsData?.data}/>
+      <MyNestList nestsData={allNests} fetchNextPage={fetchNextPage} hasNextPage={hasNextPage} isFetchingNextPage={isFetchingNextPage}/>
     </div>
   );
 }

--- a/src/app/(webview)/mypage/mycomments/page.tsx
+++ b/src/app/(webview)/mypage/mycomments/page.tsx
@@ -13,7 +13,6 @@ export default function Page() {
     if (typeof window === "undefined") return "";
     try {
       const token = window.AndroidBridge.getAccessToken();
-      console.log(token, "내 댓글");
       return token ?? "";
     } catch {
       return "";

--- a/src/app/(webview)/mypage/mycomments/page.tsx
+++ b/src/app/(webview)/mypage/mycomments/page.tsx
@@ -2,7 +2,7 @@
 
 import { fetchMyComments } from "@/lib/apiMypage";
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 import MypageHeader from '@/components/webview/mypage/MyPageHeader';
 import MyCommentList from '@/components/webview/mypage/MyCommentList';
@@ -20,12 +20,25 @@ export default function Page() {
     }
   });
 
-  //좋아요 누른 둥지 정보
-  const { data: commentData, isLoading: isCommentLoading} = useQuery({
-    queryKey: ['userComment', accessToken],
-    queryFn: () => fetchMyComments(accessToken),
+  // 내가 쓴 댓글 
+  const { 
+    data: commentData, 
+    isLoading: isCommentLoading,
+    fetchNextPage,        // 다음 페이지 호출 함수
+    hasNextPage,          // 다음 페이지 존재 여부
+    isFetchingNextPage    // 추가 페이지 로딩 상태
+  } = useInfiniteQuery({
+    queryKey: ['myComments', accessToken],
+    queryFn: ({ pageParam = 0 }) => fetchMyComments(accessToken, pageParam),
     enabled: !!accessToken,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.data.last) return undefined;
+      return lastPage.data.number + 1;
+    },
   });
+
+  const allComments = commentData?.pages.flatMap((page) => page.data.content) || [];
 
   if (!accessToken || isCommentLoading) {
     return <div className="flex justify-center items-center h-screen">로딩 중...</div>;
@@ -34,7 +47,7 @@ export default function Page() {
   return(
     <div>
       <MypageHeader title='내 댓글'/>
-      <MyCommentList commentData={commentData?.data}/>
+      <MyCommentList commentData={allComments} fetchNextPage={fetchNextPage} hasNextPage={hasNextPage} isFetchingNextPage={isFetchingNextPage}/>
     </div>
   );
 }

--- a/src/app/(webview)/mypage/page.tsx
+++ b/src/app/(webview)/mypage/page.tsx
@@ -7,6 +7,7 @@ import { uploadImageToS3 } from "@/lib/api";
 import UserDetail from '@/components/webview/mypage/UserDetail';
 import MenuButtons from "@/components/webview/mypage/MenuButtons";
 import MyNestList from "@/components/webview/mypage/MyNestList";
+import Spinner from "@/components/webview/Spinner";
 
 export default function Page() {
   const [Base64, setBase64] = useState<string>("");
@@ -69,7 +70,11 @@ export default function Page() {
   const allNests = nestsData?.pages.flatMap((page) => page.data.content) || [];
 
   if (!accessToken || isStatsLoading || isDetailLoading || isNestLoading) {
-    return <div className="flex justify-center items-center h-screen">로딩 중...</div>;
+    return (
+      <div className="flex justify-center items-center h-screen bg-white">
+        <Spinner size="lg" />
+      </div>
+  );
   }
 
   const updatedUserData = {

--- a/src/app/(webview)/mypage/page.tsx
+++ b/src/app/(webview)/mypage/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
 import { fetchUserStatistics, fetchUserDetail, fetchUserNests, patchUpdatdProfile, fetchPresignedUrl } from "@/lib/apiMypage";
 import { uploadImageToS3 } from "@/lib/api";
 import UserDetail from '@/components/webview/mypage/UserDetail';
@@ -16,14 +16,13 @@ export default function Page() {
     if (typeof window === "undefined") return "";
     try {
       const token = window.AndroidBridge.getAccessToken();
-      console.log(token, "좋아요 둥지");
+      console.log(token, "마이페이지");
       return token ?? "";
     } catch {
       return "";
     }
   });
   
-  //브릿지를 통한 accessToken 수신
   useEffect(() => {
       window.onImageReceived = (Base64: string) => {
         setBase64(Base64);
@@ -50,11 +49,24 @@ export default function Page() {
   });
 
   //유저 둥지 정보
-  const { data: nestsData, isLoading: isNestLoading} = useQuery({
+  const { 
+    data: nestsData, 
+    isLoading: isNestLoading,
+    fetchNextPage,      // 다음 페이지를 불러오는 함수
+    hasNextPage,        // 다음 페이지가 있는지 여부 (last 기반)
+    isFetchingNextPage  // 추가 페이지를 로딩 중인지 여부
+  } = useInfiniteQuery({
     queryKey: ['userNests', accessToken],
-    queryFn: () => fetchUserNests(accessToken),
+    queryFn: ({ pageParam = 0 }) => fetchUserNests(accessToken, pageParam), 
     enabled: !!accessToken,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.data.last) return undefined;
+      return lastPage.data.number + 1;
+    },
   });
+
+  const allNests = nestsData?.pages.flatMap((page) => page.data.content) || [];
 
   if (!accessToken || isStatsLoading || isDetailLoading || isNestLoading) {
     return <div className="flex justify-center items-center h-screen">로딩 중...</div>;
@@ -97,7 +109,6 @@ export default function Page() {
       await patchUpdatdProfile(payload, accessToken);
       
       console.log("프로필업데이트성공");
-      // 성공 시 모달 닫기 로직 추가 
 
       refetch();
       return true;
@@ -112,7 +123,7 @@ export default function Page() {
     <div>
       <UserDetail userStats={statsData?.data} userDetail={updatedUserData?.data} onSave={handleSave}/>
       <MenuButtons/>
-      <MyNestList nestsData={nestsData?.data}/>
+      <MyNestList nestsData={allNests} fetchNextPage={fetchNextPage} hasNextPage={hasNextPage} isFetchingNextPage={isFetchingNextPage}/>
     </div>
   );
 }

--- a/src/app/(webview)/mypage/page.tsx
+++ b/src/app/(webview)/mypage/page.tsx
@@ -17,7 +17,6 @@ export default function Page() {
     if (typeof window === "undefined") return "";
     try {
       const token = window.AndroidBridge.getAccessToken();
-      console.log(token, "마이페이지");
       return token ?? "";
     } catch {
       return "";
@@ -112,8 +111,6 @@ export default function Page() {
 
       // PATCH API 호출 
       await patchUpdatdProfile(payload, accessToken);
-      
-      console.log("프로필업데이트성공");
 
       refetch();
       return true;

--- a/src/app/(webview)/mypage/posts/page.tsx
+++ b/src/app/(webview)/mypage/posts/page.tsx
@@ -7,7 +7,7 @@ import PostcardModal from '@/components/webview/mypage/Postcard/PostcardModal';
 import Spinner from "@/components/webview/Spinner";
 import { fetchUserPostcards } from "@/lib/apiMypage";
 import type { MyPostcard } from "@/types/indexMypage";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { useState, useEffect, useMemo } from "react";
 
@@ -35,10 +35,26 @@ export default function Page() {
   });
 
   //엽서 리스트 정보
-  const { data: postcardData, isLoading: isPostCardLoading, refetch } = useQuery({
+  const { 
+    data: postcardData, 
+    isLoading: isPostCardLoading, 
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
+  } = useInfiniteQuery({
     queryKey: ['userPostcard', accessToken, activeTab], 
-    queryFn: () => fetchUserPostcards(accessToken, getFilter(activeTab)),
+    
+    queryFn: ({ pageParam = 0 }) => {
+      return fetchUserPostcards(accessToken, getFilter(activeTab), pageParam);
+    },
+    initialPageParam: 0,
     enabled: !!accessToken,
+    
+    getNextPageParam: (lastPage) => {
+      if (lastPage.data.last) return undefined;
+      return lastPage.data.number + 1;
+    }
   });
 
   useEffect(() => {
@@ -55,7 +71,7 @@ export default function Page() {
   }, [refetch]);
 
   const displayList = useMemo(() => {
-    return postcardData?.data?.content || [];
+    return postcardData?.pages.flatMap((page) => page?.data?.content || []) || [];
   }, [postcardData]);
 
   if (!accessToken) {
@@ -76,7 +92,7 @@ export default function Page() {
           <Spinner size="md" />
         </div>
       ) : (
-        <PostcardGrid items={displayList} activeTab={activeTab} onItemClick={(item) => setSelectedPostcard(item)} />
+        <PostcardGrid items={displayList} activeTab={activeTab} onItemClick={(item) => setSelectedPostcard(item)} fetchNextPage={fetchNextPage} hasNextPage={hasNextPage} isFetchingNextPage={isFetchingNextPage} />
       )}
 
       <PostcardModal 

--- a/src/app/(webview)/mypage/posts/page.tsx
+++ b/src/app/(webview)/mypage/posts/page.tsx
@@ -27,7 +27,6 @@ export default function Page() {
     if (typeof window === "undefined") return "";
     try {
       const token = window.AndroidBridge.getAccessToken();
-      console.log(token, "엽서함");
       return token ?? "";
     } catch {
       return "";

--- a/src/app/(webview)/mypage/posts/page.tsx
+++ b/src/app/(webview)/mypage/posts/page.tsx
@@ -4,14 +4,22 @@ import MyPageHeader from '@/components/webview/mypage/MyPageHeader';
 import PostCardTap from '@/components/webview/mypage/Postcard/PostcardTab';
 import PostcardGrid from '@/components/webview/mypage/Postcard/PostcardGrid';
 import PostcardModal from '@/components/webview/mypage/Postcard/PostcardModal';
+import Spinner from "@/components/webview/Spinner";
 import { fetchUserPostcards } from "@/lib/apiMypage";
 import type { MyPostcard } from "@/types/indexMypage";
 import { useQuery } from "@tanstack/react-query";
 
 import { useState, useEffect, useMemo } from "react";
 
+// filter 매칭 함수
+const getFilter = (tab: 'mine' | 'sent' | 'received') => {
+  if (tab === 'mine') return 'CREATED_NOT_SHARED';
+  if (tab === 'sent') return 'CREATED_SHARED';
+  return 'ACQUIRED';
+};
+
 export default function Page() {
-  const [activeTab, setActiveTab] = useState<'mine' | 'received'>('mine');
+  const [activeTab, setActiveTab] = useState<'mine' | 'sent' | 'received'>('mine');
   const [selectedPostcard, setSelectedPostcard] = useState<MyPostcard | null>(null);
 
   //브릿지로 accesstoken 수신
@@ -28,8 +36,8 @@ export default function Page() {
 
   //엽서 리스트 정보
   const { data: postcardData, isLoading: isPostCardLoading, refetch } = useQuery({
-    queryKey: ['userPostcard', accessToken],
-    queryFn: () => fetchUserPostcards(accessToken),
+    queryKey: ['userPostcard', accessToken, activeTab], 
+    queryFn: () => fetchUserPostcards(accessToken, getFilter(activeTab)),
     enabled: !!accessToken,
   });
 
@@ -47,21 +55,29 @@ export default function Page() {
   }, [refetch]);
 
   const displayList = useMemo(() => {
-    const postcards = postcardData?.data?.content || [];
-    return postcards.filter((post: MyPostcard) => 
-      activeTab === 'mine' ? post.mine === true : post.mine === false
-    );
-  }, [postcardData, activeTab]);
+    return postcardData?.data?.content || [];
+  }, [postcardData]);
 
-  if (!accessToken || isPostCardLoading) {
-    return <div className="flex justify-center items-center h-screen">로딩 중...</div>;
+  if (!accessToken) {
+    return (
+      <div className="flex justify-center items-center h-screen bg-white">
+        <Spinner size="lg" />
+      </div>
+    );
   }
 
   return (
     <div>
       <MyPageHeader title='엽서함'/>
       <PostCardTap currentTab={activeTab} onTabChange={setActiveTab}/>
-      <PostcardGrid items={displayList} activeTab={activeTab} onItemClick={(item) => setSelectedPostcard(item)} />
+      
+      {isPostCardLoading ? (
+        <div className="flex justify-center items-center h-[50vh]">
+          <Spinner size="md" />
+        </div>
+      ) : (
+        <PostcardGrid items={displayList} activeTab={activeTab} onItemClick={(item) => setSelectedPostcard(item)} />
+      )}
 
       <PostcardModal 
         isOpen={!!selectedPostcard} 

--- a/src/app/(webview)/mypage/posts/page.tsx
+++ b/src/app/(webview)/mypage/posts/page.tsx
@@ -39,10 +39,10 @@ export default function Page() {
       refetch(); 
     };
 
-    window.AndroidBridge.requestReload = handleAndroidRefresh;
+    window.requestReload = handleAndroidRefresh;
 
     return () => {
-      window.AndroidBridge.requestReload = () => {};
+      window.requestReload = () => {};
     };
   }, [refetch]);
 

--- a/src/app/(webview)/mypage/unlocks/page.tsx
+++ b/src/app/(webview)/mypage/unlocks/page.tsx
@@ -2,6 +2,7 @@
 
 import MyNestList from "@/components/webview/mypage/MyNestList";
 import MypageHeader from '@/components/webview/mypage/MyPageHeader';
+import Spinner from "@/components/webview/Spinner";
 
 import { useState } from "react";
 import { fetchUnlockNests } from "@/lib/apiMypage";
@@ -13,7 +14,6 @@ export default function Page() {
     if (typeof window === "undefined") return "";
     try {
       const token = window.AndroidBridge.getAccessToken();
-      console.log(token, "해금한 둥지");
       return token ?? "";
     } catch {
       return "";
@@ -41,7 +41,11 @@ export default function Page() {
   const allNests = nestsData?.pages.flatMap((page) => page.data.content) || [];
 
   if (!accessToken || isUnlockLoading) {
-    return <div className="flex justify-center items-center h-screen">로딩 중...</div>;
+    return (
+          <div className="flex justify-center items-center h-screen bg-white">
+            <Spinner size="lg" />
+          </div>
+      );
   }
 
   return (

--- a/src/app/(webview)/mypage/unlocks/page.tsx
+++ b/src/app/(webview)/mypage/unlocks/page.tsx
@@ -5,7 +5,7 @@ import MypageHeader from '@/components/webview/mypage/MyPageHeader';
 
 import { useState } from "react";
 import { fetchUnlockNests } from "@/lib/apiMypage";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 export default function Page() {
   //브릿지로 accesstoken 수신
@@ -20,12 +20,25 @@ export default function Page() {
     }
   });
 
-  //해금한 둥지 정보
-  const { data: nestsData, isLoading: isUnlockLoading} = useQuery({
-    queryKey: ['userNests', accessToken],
-    queryFn: () => fetchUnlockNests(accessToken),
+  // 해금한 둥지 정보
+  const { 
+    data: nestsData, 
+    isLoading: isUnlockLoading,
+    fetchNextPage,      // 다음 페이지를 불러오는 함수
+    hasNextPage,        // 다음 페이지가 있는지 여부 (last 기반)
+    isFetchingNextPage  // 추가 페이지를 로딩 중인지 여부
+  } = useInfiniteQuery({
+    queryKey: ['unlockNests', accessToken],
+    queryFn: ({ pageParam = 0 }) => fetchUnlockNests(accessToken, pageParam), 
     enabled: !!accessToken,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.data.last) return undefined;
+      return lastPage.data.number + 1;
+    },
   });
+
+  const allNests = nestsData?.pages.flatMap((page) => page.data.content) || [];
 
   if (!accessToken || isUnlockLoading) {
     return <div className="flex justify-center items-center h-screen">로딩 중...</div>;
@@ -34,7 +47,7 @@ export default function Page() {
   return (
     <div>
       <MypageHeader title='해금한 둥지'/>
-      <MyNestList nestsData={nestsData?.data}/>
+      <MyNestList nestsData={allNests} fetchNextPage={fetchNextPage} hasNextPage={hasNextPage} isFetchingNextPage={isFetchingNextPage}/>
     </div>
   );
 }

--- a/src/components/webview/Spinner.tsx
+++ b/src/components/webview/Spinner.tsx
@@ -1,0 +1,16 @@
+// 로딩중에 사용할 스피너 애니메이션 컴포넌트
+export default function Spinner({ size = "md" }: { size?: "sm" | "md" | "lg" }) {
+  const sizeClasses = {
+    sm: "w-4 h-4 border-2",
+    md: "w-7 h-7 border-3",
+    lg: "w-10 h-10 border-4",
+  };
+
+  return (
+    <div className="flex justify-center items-center w-full py-3">
+      <div
+        className={`${sizeClasses[size]} border-gray-200 border-t-blue-500 rounded-full animate-spin`}
+      />
+    </div>
+  );
+}

--- a/src/components/webview/mypage/MyCommentList.tsx
+++ b/src/components/webview/mypage/MyCommentList.tsx
@@ -1,6 +1,6 @@
 
 import Link from "next/link";
-import type { MyCommentsData } from "@/types/indexMypage";
+import type { MyComment } from "@/types/indexMypage";
 
 function formatDate(iso: string) {
   const d = new Date(iso);
@@ -8,11 +8,14 @@ function formatDate(iso: string) {
 }
 
 interface Props {
-  commentData: MyCommentsData | undefined;
+  commentData: MyComment[] | undefined;
+  fetchNextPage: () => void;
+  hasNextPage: boolean; 
+  isFetchingNextPage: boolean;
 }
 
-export default function MyCommentList( { commentData }: Props ) {
-  const comment = commentData?.content || [];
+export default function MyCommentList( { commentData, fetchNextPage, hasNextPage, isFetchingNextPage }: Props ) {
+  const comment = commentData || [];
 
   return(
     <div className="flex flex-col gap-3">

--- a/src/components/webview/mypage/MyCommentList.tsx
+++ b/src/components/webview/mypage/MyCommentList.tsx
@@ -1,6 +1,8 @@
 
 import Link from "next/link";
 import type { MyComment } from "@/types/indexMypage";
+import { useInView } from "react-intersection-observer";
+import Spinner from "@/components/webview/Spinner";
 
 function formatDate(iso: string) {
   const d = new Date(iso);
@@ -15,6 +17,8 @@ interface Props {
 }
 
 export default function MyCommentList( { commentData, fetchNextPage, hasNextPage, isFetchingNextPage }: Props ) {
+  const { ref, inView } = useInView();
+
   const comment = commentData || [];
 
   return(
@@ -39,6 +43,9 @@ export default function MyCommentList( { commentData, fetchNextPage, hasNextPage
             </div>
           </Link>
         ))}
+        <div ref={ref} className="flex justify-center items-center h-14">
+          {isFetchingNextPage && <Spinner size="sm" />}
+        </div>
       </div>
   )
 }

--- a/src/components/webview/mypage/MyCommentList.tsx
+++ b/src/components/webview/mypage/MyCommentList.tsx
@@ -19,11 +19,11 @@ interface Props {
 export default function MyCommentList( { commentData, fetchNextPage, hasNextPage, isFetchingNextPage }: Props ) {
   const { ref, inView } = useInView();
 
-  const comment = commentData || [];
+  const comments = commentData || [];
 
   return(
     <div className="flex flex-col gap-3">
-        {comment.map((comment) => (
+        {comments.map((comment) => (
           <Link
             key={comment.id}
             href={`/nests/${comment.nestId}`} // 상세 페이지 경로
@@ -45,6 +45,9 @@ export default function MyCommentList( { commentData, fetchNextPage, hasNextPage
         ))}
         <div ref={ref} className="flex justify-center items-center h-14">
           {isFetchingNextPage && <Spinner size="sm" />}
+          {!isFetchingNextPage && !hasNextPage && comments.length > 0 && (
+            <p className="text-xs text-gray-400 mt-2">모든 둥지를 확인했어요!</p>
+          )}
         </div>
       </div>
   )

--- a/src/components/webview/mypage/MyCommentList.tsx
+++ b/src/components/webview/mypage/MyCommentList.tsx
@@ -54,7 +54,7 @@ export default function MyCommentList( { commentData, fetchNextPage, hasNextPage
         <div ref={ref} className="flex justify-center items-center h-14">
           {isFetchingNextPage && <Spinner size="sm" />}
           {!isFetchingNextPage && !hasNextPage && comments.length > 0 && (
-            <p className="text-xs text-gray-400 mt-2">모든 댓글을 확인했어요!</p>
+            <p className="text-xs text-[#54513E] mt-2">모든 댓글을 확인했어요!</p>
           )}
         </div>
       </div>

--- a/src/components/webview/mypage/MyCommentList.tsx
+++ b/src/components/webview/mypage/MyCommentList.tsx
@@ -1,7 +1,9 @@
+"use client";
 
 import Link from "next/link";
 import type { MyComment } from "@/types/indexMypage";
 import { useInView } from "react-intersection-observer";
+import { useEffect } from "react";
 import Spinner from "@/components/webview/Spinner";
 
 function formatDate(iso: string) {
@@ -20,6 +22,12 @@ export default function MyCommentList( { commentData, fetchNextPage, hasNextPage
   const { ref, inView } = useInView();
 
   const comments = commentData || [];
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage(); 
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return(
     <div className="flex flex-col gap-3">
@@ -46,7 +54,7 @@ export default function MyCommentList( { commentData, fetchNextPage, hasNextPage
         <div ref={ref} className="flex justify-center items-center h-14">
           {isFetchingNextPage && <Spinner size="sm" />}
           {!isFetchingNextPage && !hasNextPage && comments.length > 0 && (
-            <p className="text-xs text-gray-400 mt-2">모든 둥지를 확인했어요!</p>
+            <p className="text-xs text-gray-400 mt-2">모든 댓글을 확인했어요!</p>
           )}
         </div>
       </div>

--- a/src/components/webview/mypage/MyNestList.tsx
+++ b/src/components/webview/mypage/MyNestList.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useEffect } from "react";
 import type { MyNestDetail } from "@/types/indexMypage";
 import { useInView } from "react-intersection-observer";
+import Spinner from "@/components/webview/Spinner";
 
 interface Props {
   nestsData: MyNestDetail[] | undefined;
@@ -67,8 +68,8 @@ export default function MyNestList({ nestsData, fetchNextPage, hasNextPage, isFe
             </div>
           </Link>
         ))}
-        <div ref={ref} className="h-10">
-          {isFetchingNextPage && "로딩 중..."}
+        <div ref={ref} className="flex justify-center items-center h-14">
+          {isFetchingNextPage && <Spinner size="sm" />}
         </div>
       </div>
 

--- a/src/components/webview/mypage/MyNestList.tsx
+++ b/src/components/webview/mypage/MyNestList.tsx
@@ -74,7 +74,7 @@ export default function MyNestList({ nestsData, fetchNextPage, hasNextPage, isFe
 
       {nests.length === 0 && (
         <div className="py-20 text-center text-gray-400 text-sm">
-          아직 작성한 둥지가 없어요!
+          아직 둥지가 없어요!
         </div>
       )}
     </section>

--- a/src/components/webview/mypage/MyNestList.tsx
+++ b/src/components/webview/mypage/MyNestList.tsx
@@ -70,6 +70,9 @@ export default function MyNestList({ nestsData, fetchNextPage, hasNextPage, isFe
         ))}
         <div ref={ref} className="flex justify-center items-center h-14">
           {isFetchingNextPage && <Spinner size="sm" />}
+          {!isFetchingNextPage && !hasNextPage && nests.length > 0 && (
+            <p className="text-xs text-gray-400 mt-2">모든 댓글을 확인했어요!</p>
+          )}
         </div>
       </div>
 

--- a/src/components/webview/mypage/MyNestList.tsx
+++ b/src/components/webview/mypage/MyNestList.tsx
@@ -71,13 +71,13 @@ export default function MyNestList({ nestsData, fetchNextPage, hasNextPage, isFe
         <div ref={ref} className="flex justify-center items-center h-14">
           {isFetchingNextPage && <Spinner size="sm" />}
           {!isFetchingNextPage && !hasNextPage && nests.length > 0 && (
-            <p className="text-xs text-gray-400 mt-2">모든 둥지를 확인했어요!</p>
+            <p className="text-xs text-[#54513E] mt-2">모든 둥지를 확인했어요!</p>
           )}
         </div>
       </div>
 
       {nests.length === 0 && (
-        <div className="py-20 text-center text-gray-400 text-sm">
+        <div className="py-20 text-center text-[#54513E] text-sm">
           아직 둥지가 없어요!
         </div>
       )}

--- a/src/components/webview/mypage/MyNestList.tsx
+++ b/src/components/webview/mypage/MyNestList.tsx
@@ -45,7 +45,7 @@ export default function MyNestList({ nestsData, fetchNextPage, hasNextPage, isFe
             className="flex flex-row gap-5 p-4 w-[90vw] bg-white rounded-2xl border border-gray-100 shadow-sm active:bg-gray-50 active:scale-[0.98] transition-all"
           >
             {nest.thumbnailUrl && (
-              <div className="flex-shrink-0 w-16 h-16 rounded-xl overflow-hidden bg-gray-100">
+              <div className="flex-shrink-0 w-16 h-16 rounded-xl relative overflow-hidden bg-gray-100">
                 <Image
                   src={nest.thumbnailUrl}
                   alt="thumbnail"

--- a/src/components/webview/mypage/MyNestList.tsx
+++ b/src/components/webview/mypage/MyNestList.tsx
@@ -71,7 +71,7 @@ export default function MyNestList({ nestsData, fetchNextPage, hasNextPage, isFe
         <div ref={ref} className="flex justify-center items-center h-14">
           {isFetchingNextPage && <Spinner size="sm" />}
           {!isFetchingNextPage && !hasNextPage && nests.length > 0 && (
-            <p className="text-xs text-gray-400 mt-2">모든 댓글을 확인했어요!</p>
+            <p className="text-xs text-gray-400 mt-2">모든 둥지를 확인했어요!</p>
           )}
         </div>
       </div>

--- a/src/components/webview/mypage/MyNestList.tsx
+++ b/src/components/webview/mypage/MyNestList.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import type { MyNestData } from "@/types/indexMypage";
+import Image from 'next/image';
+import { useEffect } from "react";
+import type { MyNestDetail } from "@/types/indexMypage";
+import { useInView } from "react-intersection-observer";
 
 interface Props {
-  nestsData: MyNestData | undefined;
+  nestsData: MyNestDetail[] | undefined;
+  fetchNextPage: () => void;
+  hasNextPage: boolean; 
+  isFetchingNextPage: boolean;
 }
 
 function formatDate(iso: string) {
@@ -12,8 +18,15 @@ function formatDate(iso: string) {
   return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
 }
 
-export default function MyNestList({ nestsData }: Props) {
-  const nests = nestsData?.content || [];
+export default function MyNestList({ nestsData, fetchNextPage, hasNextPage, isFetchingNextPage }: Props) {
+  const { ref, inView } = useInView();
+  const nests = nestsData || [];
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
   
   return (
     <section className="w-full mt-8 px-5 pb-20">
@@ -32,9 +45,10 @@ export default function MyNestList({ nestsData }: Props) {
           >
             {nest.thumbnailUrl && (
               <div className="flex-shrink-0 w-16 h-16 rounded-xl overflow-hidden bg-gray-100">
-                <img
+                <Image
                   src={nest.thumbnailUrl}
                   alt="thumbnail"
+                  fill
                   className="w-full h-full object-cover"
                 />
               </div>
@@ -53,6 +67,9 @@ export default function MyNestList({ nestsData }: Props) {
             </div>
           </Link>
         ))}
+        <div ref={ref} className="h-10">
+          {isFetchingNextPage && "로딩 중..."}
+        </div>
       </div>
 
       {nests.length === 0 && (

--- a/src/components/webview/mypage/Postcard/PostcardGrid.tsx
+++ b/src/components/webview/mypage/Postcard/PostcardGrid.tsx
@@ -5,7 +5,7 @@ import { ImagePlus, Images } from 'lucide-react';
 
 interface GridProps {
   items: MyPostcard[];
-  activeTab: 'mine' | 'received';
+  activeTab: 'mine' | 'sent' | 'received';
   onItemClick: (item: MyPostcard) => void; // 클릭 함수 타입 추가
 }
 

--- a/src/components/webview/mypage/Postcard/PostcardGrid.tsx
+++ b/src/components/webview/mypage/Postcard/PostcardGrid.tsx
@@ -35,25 +35,26 @@ export default function PostcardGrid({ items, activeTab, onItemClick, fetchNextP
    console.log("엽서 생성 요청");
   };
   return (
-    <div className="grid grid-cols-3 gap-1">
-      {activeTab === 'mine' && (
-        <div 
-          onClick={handleCreatePostcard}
-          className="aspect-square flex flex-col items-center justify-center bg-gray-200 border-2 border-dashed border-[#54513E] cursor-pointer hover:bg-gray-100 transition-colors"
-        >
-          <ImagePlus size={24} color="#54513E" />
-          <span className="text-xs text-[#54513E] mt-1">엽서 만들기</span>
-        </div>
-      )}
+    <div>
+      <div className="grid grid-cols-3 gap-1">
+        {activeTab === 'mine' && (
+          <div 
+            onClick={handleCreatePostcard}
+            className="aspect-square flex flex-col items-center justify-center bg-gray-200 border-2 border-dashed border-[#54513E] cursor-pointer hover:bg-gray-100 transition-colors"
+          >
+            <ImagePlus size={24} color="#54513E" />
+            <span className="text-xs text-[#54513E] mt-1">엽서 만들기</span>
+          </div>
+        )}
 
-      {items.map((item) => (
-        <PostcardItem key={item.id} item={item} onClick={() => onItemClick(item)}/>
-      ))}
-
-      <div ref={ref} className="flex justify-center items-center h-14">
+        {items.map((item) => (
+          <PostcardItem key={item.id} item={item} onClick={() => onItemClick(item)}/>
+        ))}
+      </div>
+      <div ref={ref} className="flex w-full justify-center items-end h-14">
         {isFetchingNextPage && <Spinner size="sm" />}
         {!isFetchingNextPage && !hasNextPage && items.length > 0 && (
-          <p className="text-xs text-gray-400 mt-2">모든 엽서를 확인했어요!</p>
+          <p className="text-xs text-[#54513E] pb-2">모든 엽서를 확인했어요!</p>
         )}
       </div>
     </div>

--- a/src/components/webview/mypage/Postcard/PostcardGrid.tsx
+++ b/src/components/webview/mypage/Postcard/PostcardGrid.tsx
@@ -2,14 +2,28 @@
 import Image from 'next/image';
 import type { MyPostcard } from "@/types/indexMypage";
 import { ImagePlus, Images } from 'lucide-react';
+import { useEffect } from "react";
+import { useInView } from "react-intersection-observer";
+import Spinner from "@/components/webview/Spinner";
 
 interface GridProps {
   items: MyPostcard[];
   activeTab: 'mine' | 'sent' | 'received';
   onItemClick: (item: MyPostcard) => void; // 클릭 함수 타입 추가
+  fetchNextPage: () => void;
+  hasNextPage: boolean; 
+  isFetchingNextPage: boolean;
 }
 
-export default function PostcardGrid({ items, activeTab, onItemClick }: GridProps ) {
+export default function PostcardGrid({ items, activeTab, onItemClick, fetchNextPage, hasNextPage, isFetchingNextPage }: GridProps ) {
+  const { ref, inView } = useInView();
+  
+  useEffect(() => {
+      if (inView && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  
   console.log("ActiveTap: ", activeTab);
 
   const handleCreatePostcard = () => {
@@ -35,6 +49,13 @@ export default function PostcardGrid({ items, activeTab, onItemClick }: GridProp
       {items.map((item) => (
         <PostcardItem key={item.id} item={item} onClick={() => onItemClick(item)}/>
       ))}
+
+      <div ref={ref} className="flex justify-center items-center h-14">
+        {isFetchingNextPage && <Spinner size="sm" />}
+        {!isFetchingNextPage && !hasNextPage && items.length > 0 && (
+          <p className="text-xs text-gray-400 mt-2">모든 엽서를 확인했어요!</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/webview/mypage/Postcard/PostcardModal.tsx
+++ b/src/components/webview/mypage/Postcard/PostcardModal.tsx
@@ -38,7 +38,7 @@ export default function PostcardModal({ isOpen, onClose, postcardData }: Postcar
         </button>
 
         {/* 엽서 이미지 영역 */}
-        <div className="relative aspect-[4/3] w-full bg-gray-100">
+        <div className="relative relative aspect-[4/3] w-full bg-gray-100">
           <Image 
             src={postcardData.imageUrl} 
             alt={postcardData.content}

--- a/src/components/webview/mypage/Postcard/PostcardModal.tsx
+++ b/src/components/webview/mypage/Postcard/PostcardModal.tsx
@@ -38,7 +38,7 @@ export default function PostcardModal({ isOpen, onClose, postcardData }: Postcar
         </button>
 
         {/* 엽서 이미지 영역 */}
-        <div className="relative relative aspect-[4/3] w-full bg-gray-100">
+        <div className="relative aspect-[4/3] w-full bg-gray-100">
           <Image 
             src={postcardData.imageUrl} 
             alt={postcardData.content}

--- a/src/components/webview/mypage/Postcard/PostcardTab.tsx
+++ b/src/components/webview/mypage/Postcard/PostcardTab.tsx
@@ -1,8 +1,8 @@
 //엽서함에서 내 엽서 / 받은 엽서 버튼 컴포넌트
 
 interface PostcardTabProps {
-  currentTab: 'mine' | 'received';
-  onTabChange: (tab: 'mine' | 'received') => void;
+  currentTab: 'mine' | 'sent' | 'received';
+  onTabChange: (tab: 'mine'| 'sent' | 'received') => void;
 }
 
 export default function PostcardTab({ currentTab, onTabChange }: PostcardTabProps) {
@@ -10,13 +10,19 @@ export default function PostcardTab({ currentTab, onTabChange }: PostcardTabProp
     <div className="flex w-full border-b">
       <button 
         onClick={() => onTabChange('mine')}
-        className={`flex-1 py-3 ${currentTab === 'mine' ? 'border-b-2 border-[#54513E] text-[#54513E] font-bold shadow-sm' : 'text-[#54513E]-50'}`}
+        className={`flex-1 py-3 ${currentTab === 'mine' ? 'border-b-2 border-[#54513E] text-[#54513E] font-bold shadow-sm' : 'text-[#54513E]/50'}`}
       >
-        나의 엽서함
+        보유 엽서함
+      </button>
+      <button 
+        onClick={() => onTabChange('sent')}
+        className={`flex-1 py-3 ${currentTab === 'sent' ? 'border-b-2 border-[#54513E] text-[#54513E] font-bold shadow-sm' : 'text-[#54513E]/50'}`}
+      >
+        보낸 엽서함
       </button>
       <button 
         onClick={() => onTabChange('received')}
-        className={`flex-1 py-3 ${currentTab === 'received' ? 'border-b-2 border-[#54513E] text-[#54513E] font-bold shadow-sm' : 'text-[#54513E]-30'}`}
+        className={`flex-1 py-3 ${currentTab === 'received' ? 'border-b-2 border-[#54513E] text-[#54513E] font-bold shadow-sm' : 'text-[#54513E]/50'}`}
       >
         받은 엽서함
       </button>

--- a/src/lib/apiMypage.ts
+++ b/src/lib/apiMypage.ts
@@ -87,7 +87,7 @@ export async function fetchUserPostcards(
   filter: string,
   page: number,
 ): Promise<MyPostcardApiResponse> {
-  const res = await fetch(`${BASE_URL}/api/v1/mypage/postcards?filter=${filter}?page=${page}`, {
+  const res = await fetch(`${BASE_URL}/api/v1/mypage/postcards?filter=${filter}&page=${page}`, {
     method: "GET",
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",

--- a/src/lib/apiMypage.ts
+++ b/src/lib/apiMypage.ts
@@ -56,8 +56,9 @@ export async function fetchUserNests(
 // 유저가 좋아요 누른 둥지를 불러오는 함수
 export async function fetchLikesNests(
   accessToken: string,
+  page: number,
 ): Promise<MyNestApiResponse> {
-  const res = await fetch(`${BASE_URL}/api/v1/mypage/likes`, {
+  const res = await fetch(`${BASE_URL}/api/v1/mypage/likes?page=${page}`, {
     method: "GET",
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",
@@ -69,8 +70,9 @@ export async function fetchLikesNests(
 // 유저가 해금한 둥지를 불러오는 함수
 export async function fetchUnlockNests(
   accessToken: string,
+  page: number,
 ): Promise<MyNestApiResponse> {
-  const res = await fetch(`${BASE_URL}/api/v1/mypage/unlocks`, {
+  const res = await fetch(`${BASE_URL}/api/v1/mypage/unlocks?page=${page}`, {
     method: "GET",
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",
@@ -111,8 +113,9 @@ export async function patchUpdatdProfile(
 // 유저가 작성한 댓글을 불러오는 함수
 export async function fetchMyComments(
   accessToken: string,
+  page: number,
 ): Promise<MyCommentsApiResponse> {
-  const res = await fetch(`${BASE_URL}/api/v1/mypage/comments`, {
+  const res = await fetch(`${BASE_URL}/api/v1/mypage/comments?page=${page}`, {
     method: "GET",
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",

--- a/src/lib/apiMypage.ts
+++ b/src/lib/apiMypage.ts
@@ -42,8 +42,9 @@ export async function fetchUserDetail(
 // 유저가 작성한 둥지를 불러오는 함수
 export async function fetchUserNests(
   accessToken: string,
+  page: number,
 ): Promise<MyNestApiResponse> {
-  const res = await fetch(`${BASE_URL}/api/v1/mypage/nests`, {
+  const res = await fetch(`${BASE_URL}/api/v1/mypage/nests?page=${page}`, {
     method: "GET",
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",

--- a/src/lib/apiMypage.ts
+++ b/src/lib/apiMypage.ts
@@ -85,8 +85,9 @@ export async function fetchUnlockNests(
 export async function fetchUserPostcards(
   accessToken: string,
   filter: string,
+  page: number,
 ): Promise<MyPostcardApiResponse> {
-  const res = await fetch(`${BASE_URL}/api/v1/mypage/postcards?filter=${filter}`, {
+  const res = await fetch(`${BASE_URL}/api/v1/mypage/postcards?filter=${filter}?page=${page}`, {
     method: "GET",
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",

--- a/src/lib/apiMypage.ts
+++ b/src/lib/apiMypage.ts
@@ -84,8 +84,9 @@ export async function fetchUnlockNests(
 // 유저의 엽서를 불러오는 함수
 export async function fetchUserPostcards(
   accessToken: string,
+  filter: string,
 ): Promise<MyPostcardApiResponse> {
-  const res = await fetch(`${BASE_URL}/api/v1/mypage/postcards`, {
+  const res = await fetch(`${BASE_URL}/api/v1/mypage/postcards?filter=${filter}`, {
     method: "GET",
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",

--- a/src/types/bridge.d.ts
+++ b/src/types/bridge.d.ts
@@ -15,11 +15,12 @@ declare global {
       getNestDetailId: () => string;
 
       requestPostcardMake: () => void;
-      requestReload: () => void;
     };
     onInitialData?: (data: string) => void;
     onImageUploaded?: (imageUrl: string) => void;
     onImageReceived?: (base64Data: string) => void;
+    
+    requestReload: () => void;
   }
 }
 


### PR DESCRIPTION
## 📌 개요 (Overview)
마이페이지 스크롤 구현 (내가 쓴 둥지, 좋아요 누른 둥지, 해금 둥지, 내 댓글, 엽서함)
엽서함 분리 (보유 엽서, 보낸 엽서, 받은 엽서)

## 🛠️ 작업 내용 (Changes)
- [ ] 스크롤 하단 감지 및 다음 페이지 로드 트리거 작성
- [ ] 내 둥지, 좋아요 둥지, 해금 둥지, 작성 댓글 리스트 각각에 페이징 연동
- [ ] 리스트 하단 데이터 로딩 시 보여줄 스피너(Spinner) UI 추가
- [ ] 모든 데이터를 불러왔을 때 표시할 문구 처리
- [ ] 엽서함 분리 (보유 엽서, 보낸 엽서, 받은 엽서)